### PR TITLE
Enclave NPCs because we need more mobs to bash

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/Enclave.dm
+++ b/code/modules/mob/living/simple_animal/hostile/Enclave.dm
@@ -1,0 +1,81 @@
+
+/mob/living/simple_animal/hostile/enclave
+    //default value if no values are defined in the mobs themselves
+	name = "Enclave soldier"
+	desc = "America will rise again."
+	icon = 'icons/mob/simple_human.dmi'
+	icon_state = "enclave" //add a sprite (default enclave appearance if no others are defined for the differents goons)
+	icon_living = "enclave"  // add a sprite
+	icon_dead = "enclave_dead" //add a sprite or keep it like that if we keep gibbing them on death
+	icon_gib = "syndicate_gib"
+	mob_biotypes = list(MOB_ORGANIC, MOB_HUMANOID)
+	speak_chance = 0
+	turns_per_move = 5
+	response_help = "pokes"
+	response_disarm = "shoves"
+	response_harm = "hits"
+	speed = 0
+	stat_attack = UNCONSCIOUS
+	robust_searching = 1
+	maxHealth = 100
+	health = 100
+	harm_intent_damage = 5
+	melee_damage_lower = 10
+	melee_damage_upper = 10
+	attacktext = "punches"
+	attack_sound = 'sound/weapons/punch1.ogg'
+	a_intent = INTENT_HARM
+	loot = list(/obj/effect/mob_spawn/human/corpse/syndicatesoldier)
+	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
+	unsuitable_atmos_damage = 15
+	faction = list(ROLE_SYNDICATE) //add an enclave faction instead of syndie if we want them not to fire at enclave PCs
+	check_friendly_fire = 1
+	status_flags = CANPUSH
+	del_on_death = 1
+
+
+
+
+
+/mob/living/simple_animal/hostile/enclave/recruit //basic goon
+     //combat values = 3burst to crit an unarmored, 4 for CA or T45 , 5 + 1shot connecting for a T51
+	ranged = 1
+	extra_projectiles = 2
+	retreat_distance = 5
+	minimum_distance = 5
+	//Fluff elements
+	name = "Enclave recruit"
+	desc = "A poorly armored recruit armed with a burst fire AER7."
+	//wich sprites we use
+	icon_state = "syndicateranged"
+	icon_living = "syndicateranged"
+	//wich weapon is used
+	projectilesound = 'sound/f13weapons/laser_pistol.ogg'
+	projectiletype = /obj/item/projectile/beam/laser/enclaveAER7
+	loot = list(/obj/effect/gibspawner/human)
+	//some flavor quotes, have fun adding to them
+	speak = list("Mutie SCUM!","DIE!","FOR THE US!","I SEE YOU, SCUM!")
+	speak_emote = list("swear loudly")
+	emote_taunt = list("stares ferociously", "Aim his gun")
+	speak_chance = 10
+	taunt_chance = 25
+
+
+/mob/living/simple_animal/hostile/enclave/Soldier //better equipped goon
+    //crit unarmored in two bursts, CA and T45 in 3, T51 in 4
+	ranged = 1
+	extra_projectiles = 1
+	retreat_distance = 5
+	minimum_distance = 5
+	name = "Enclave soldier"
+	desc = "A well armored veteran armed with a modified AER9."
+	icon_state = "syndicaterangedstormtrooper"
+	icon_living = "syndicaterangedstormtrooper"
+	projectilesound = 'sound/f13weapons/laser_rifle.ogg'
+	projectiletype = /obj/item/projectile/beam/laser/enclaveAER9
+	loot = list(/obj/effect/gibspawner/human)
+	speak = list("REMEMBER THE RIG!","DIE!","FOR THE US of A!","BURN IN HELL!")
+	speak_emote = list("swear loudly")
+	emote_taunt = list("stares ferociously", "Aim his gun")
+	speak_chance = 10
+	taunt_chance = 25

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -207,3 +207,11 @@
 
 /obj/item/projectile/plasma/scatter
 	damage = 25
+
+/obj/item/projectile/beam/laser/enclaveAER9 //only used for the enclave soldier NPC
+	damage = 25
+	armour_penetration = 10
+
+/obj/item/projectile/beam/laser/enclaveAER7 //only used for the enclave recruit NPC
+	damage = 11
+	armour_penetration = 10


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added two new NPCs (trooper and recruit) under enclave.dm, they use syndies sprite until we can get a spriter,  they features custom quotes and description
Added new beam types to projectiles/Beam to store their weapons datas

## Motivation and Context
More mob to bash  and fixing the operative doing no damages

## How Has This Been Tested?

Tested on my local server, both were tested against static PCs wearing nothing, CA, T45 and T51.
Test results are in Enclave.dm

## Changelog (necessary)
:cl:
add: Enclave.dm to mob
tweak: tweaked Beam.dm to store the new projectiles they use
fix: instead of using the syndie op use the new mobs

