### PR TITLE
Fixing mob limit

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -1406,8 +1406,170 @@
 	name = "enclave recruit loot"
 	lootcount = 2 //how many tiems will it drops
 	loot = list(
-			/obj/item/reagent_containers/hypospray/medipen/stimpak = 10,///14%to drop a stimm7%to drop a stimm
+			/obj/item/reagent_containers/hypospray/medipen/stimpak = 10,///10%to drop a stimm
 			"" = 35,//chance to have no items spawn
 			"" = 35,//having it twice to have "no drop" moments as we pick two items
 			/obj/item/stock_parts/cell/ammo/ec =20
+			)
+
+/obj/effect/spawner/lootdrop/f13/Enclavesoldier
+	name = "enclave soldier loot"
+	lootcount = 2 //how many tiems will it drops
+	loot = list(
+			/obj/item/reagent_containers/hypospray/medipen/stimpak = 10,///10%to drop a stimm
+			"" = 25,//chance to have no items spawn
+			"" = 25,//having it twice to have "no drop" moments as we pick two items
+			/obj/item/stock_parts/cell/ammo/mfc =15,
+			/obj/effect/spawner/lootdrop/f13/cash_random_low = 25
+			)
+
+/obj/effect/spawner/lootdrop/f13/Enclaveelite
+	name = "enclave elite loot"
+	lootcount = 3 //how many tiems will it drops
+	loot = list(
+			/obj/item/reagent_containers/hypospray/medipen/stimpak/super = 15,///15%to drop a stimm
+			"" = 20,//chance to have no items spawn
+			"" = 15,//having it twice to have "no drop" moments as we pick two items
+			/obj/item/stock_parts/cell/ammo/mfc =20,
+			/obj/effect/spawner/lootdrop/f13/cash_random_med = 30
+			)
+
+/obj/effect/spawner/lootdrop/f13/Enclaveofficer
+	name = "enclave officer loot"
+	lootcount = 3 //how many tiems will it drops
+	loot = list(
+			/obj/item/reagent_containers/hypospray/medipen/stimpak = 15,
+			/obj/item/reagent_containers/hypospray/medipen/stimpak/super = 15,
+			"" = 15,//chance to have no items spawn
+			"" = 15,//having it twice to have "no drop" moments as we pick two items
+			/obj/item/stock_parts/cell/ammo/mfc =10,
+			/obj/item/stack/f13Cash/random/bottle_cap/high = 30
+			)
+
+/obj/effect/spawner/lootdrop/f13/mrhandy
+	name = "Mr handy loot"
+	lootcount = 2 //how many tiems will it drops
+	loot = list(
+			"" = 25,//chance to have no items spawn
+			"" = 25,//having it twice to have "no drop" moments as we pick two items
+			/obj/item/stock_parts/cell/ammo/mfc =20,
+			/obj/effect/spawner/lootdrop/f13/cash_random_low = 30		)
+
+/obj/effect/spawner/lootdrop/f13/mrgusty
+	name = "MR gusty loot"
+	lootcount = 2 //how many tiems will it drops
+	loot = list(
+			"" = 15,//chance to have no items spawn
+			"" = 15,//having it twice to have "no drop" moments as we pick two items
+			/obj/item/stock_parts/cell/ammo/mfc =30,
+			/obj/effect/spawner/lootdrop/f13/cash_random_med = 40
+			)
+
+/obj/effect/spawner/lootdrop/f13/protectrons
+	name = "protectrons loot"
+	lootcount = 3 //how many tiems will it drops
+	loot = list(
+			/obj/item/reagent_containers/hypospray/medipen/stimpak = 15,
+			"" = 25,//chance to have no items spawn
+			"" = 22,//having it twice to have "no drop" moments as we pick two items
+			/obj/item/stock_parts/cell/ammo/mfc =15,
+			/obj/effect/spawner/lootdrop/f13/cash_random_low = 20,
+			/obj/item/dildo = 3
+			)
+
+/obj/effect/spawner/lootdrop/f13/sentrybot
+	name = "sentry bot loot"
+	lootcount = 3 //how many tiems will it drops
+	loot = list(
+			/obj/item/reagent_containers/hypospray/medipen/stimpak = 15,
+			/obj/item/reagent_containers/hypospray/medipen/stimpak/super = 15,
+			"" = 15,//chance to have no items spawn
+			"" = 15,//having it twice to have "no drop" moments as we pick two items
+			/obj/item/stock_parts/cell/ammo/mfc =10,
+			/obj/effect/spawner/lootdrop/f13/cash_random_med = 30
+			)
+
+/obj/effect/spawner/lootdrop/f13/deathclaw
+	name = "deathclaw loot"
+	lootcount = 2 //how many tiems will it drops
+	loot = list(
+			/obj/item/reagent_containers/hypospray/medipen/stimpak = 15,
+			/obj/item/reagent_containers/hypospray/medipen/stimpak/super = 10,
+			"" = 20,
+			"" = 20,
+			/obj/effect/spawner/lootdrop/f13/cash_random_med = 35
+			)
+
+/obj/effect/spawner/lootdrop/f13/deathclawmother
+	name = "deathclaw mother loot"
+	lootcount = 2 //how many tiems will it drops
+	loot = list(
+			/obj/item/reagent_containers/hypospray/medipen/stimpak = 25,
+			/obj/item/reagent_containers/hypospray/medipen/stimpak/super = 20,
+			"" = 10,
+			"" = 10,
+			/obj/effect/spawner/lootdrop/f13/cash_random_high = 35
+			)
+
+/obj/effect/spawner/lootdrop/f13/centaur
+	name = "centaur loot"
+	lootcount = 2 //how many tiems will it drops
+	loot = list(
+			/obj/item/reagent_containers/hypospray/medipen/stimpak = 10,
+			/obj/item/reagent_containers/hypospray/medipen/stimpak/super = 5,
+			/obj/effect/spawner/lootdrop/f13/junkspawners= 30,
+			"" = 30,
+			/obj/effect/spawner/lootdrop/f13/cash_random_low = 10,
+			/obj/item/dildo = 5,
+			/obj/effect/spawner/lootdrop/f13/junkspawners =10
+			)
+
+/obj/effect/spawner/lootdrop/f13/ghoul
+	name = "ghoul loot"
+	lootcount = 2 //how many tiems will it drops
+	loot = list(
+			/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1 = 10,
+			/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2 = 5,
+			/obj/effect/spawner/lootdrop/f13/junkspawners= 30,
+			/obj/effect/spawner/lootdrop/f13/cash_random_low = 30,
+			/obj/effect/spawner/lootdrop/f13/junkspawners =10,
+			/obj/effect/spawner/lootdrop/f13/alcoholspawner = 10,
+			/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds = 5
+			)
+
+/obj/effect/spawner/lootdrop/f13/ghoulreaver
+	name = "ghoul reaver loot"
+	lootcount = 2 //how many tiems will it drops
+	loot = list(
+			/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2 = 15,
+			/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3 = 10,
+			/obj/effect/spawner/lootdrop/f13/junkspawners= 5,
+			/obj/effect/spawner/lootdrop/f13/cash_random_low = 45,
+			/obj/effect/spawner/lootdrop/f13/junkspawners =5,
+			/obj/effect/spawner/lootdrop/f13/alcoholspawner = 5,
+			/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds = 15
+			)
+
+
+/obj/effect/spawner/lootdrop/f13/ghoulglowing
+	name = "glowing one loot"
+	lootcount = 3 //how many tiems will it drops
+	loot = list(
+			/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3 = 15,
+			/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4 = 10,
+			/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5 = 5,
+			/obj/effect/spawner/lootdrop/f13/cash_random_med = 45,
+			/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds = 25
+			)
+
+/obj/effect/spawner/lootdrop/f13/supermutants
+	name = "supermutants loot"
+	lootcount = 2 //how many tiems will it drops
+	loot = list(
+			/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2 = 15,
+			/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3 = 10,
+			/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3 = 20 ,
+			/obj/effect/spawner/lootdrop/f13/cash_random_low = 35,
+			/obj/effect/spawner/lootdrop/f13/weapon/melee/tier4 = 5,
+			/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds = 15
 			)

--- a/code/modules/mob/living/simple_animal/Enclave.dm
+++ b/code/modules/mob/living/simple_animal/Enclave.dm
@@ -1,0 +1,144 @@
+/mob/living/simple_animal/hostile/enclave
+    //default value if no values are defined in the mobs themselves // don't use this mob, he is a placeholder and has no sprite
+	name = "Enclave soldier"
+	desc = "America will rise again."
+	icon = 'icons/mob/simple_human.dmi'
+	icon_state = "enclave" //add a sprite (default enclave appearance if no others are defined for the differents goons)
+	icon_living = "enclave"  // add a sprite
+	icon_dead = "enclave_dead" //add a sprite or keep it like that if we keep gibbing them on death
+	icon_gib = "syndicate_gib"
+	mob_biotypes = list(MOB_ORGANIC, MOB_HUMANOID)
+	speak_chance = 0
+	turns_per_move = 5
+	response_help = "pokes"
+	response_disarm = "shoves"
+	response_harm = "hits"
+	speed = 0
+	stat_attack = UNCONSCIOUS
+	robust_searching = 1
+	maxHealth = 100
+	health = 100
+	harm_intent_damage = 5
+	melee_damage_lower = 10
+	melee_damage_upper = 10
+	attacktext = "punches"
+	attack_sound = 'sound/weapons/punch1.ogg'
+	a_intent = INTENT_HARM
+	loot = list(/obj/effect/mob_spawn/human/corpse/enclave)
+	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
+	unsuitable_atmos_damage = 15
+	faction = list(ROLE_SYNDICATE) //add an enclave faction instead of syndie if we want them not to fire at enclave PCs
+	check_friendly_fire = 1
+	status_flags = CANPUSH
+	del_on_death = 1
+
+/mob/living/simple_animal/hostile/enclave/recruit //basic goon
+     //combat values = 3burst to crit an unarmored, 4 for CA or T45 , 5 + 1shot connecting for a T51
+	ranged = 1
+	maxHealth = 75 //zergling HP, deploy in mass
+	health = 75
+	extra_projectiles = 2
+	retreat_distance = 3
+	minimum_distance = 2
+	//Fluff elements
+	name = "Enclave recruit"
+	desc = "A poorly armored recruit armed with a burst fire AER7."
+	//wich sprites we use
+	icon_state = "syndicateranged"
+	icon_living = "syndicateranged"
+	//wich weapon is used
+	projectilesound = 'sound/f13weapons/laser_pistol.ogg'
+	projectiletype = /obj/item/projectile/beam/laser/enclaveAER7
+	//what loot he drop,the loot itself is spawned along the body (see Ecorpses)
+	loot = list(/obj/effect/mob_spawn/human/corpse/enclaverecruit , /obj/effect/spawner/lootdrop/f13/Enclaverecruit)
+	//some flavor quotes, have fun adding to them
+	speak = list("Muties are there!","DIE!","FOR THE US!","I SEE MUTATED SCUM!")
+	speak_emote = list("swear loudly")
+	emote_taunt = list("stares ferociously", "Aim his gun")
+	speak_chance = 10
+	taunt_chance = 25
+
+/mob/living/simple_animal/hostile/enclave/Trooper //better equipped goon
+    //crit unarmored in two bursts, CA and T45 in 3, T51 in 4
+	ranged = 1
+	maxHealth = 150
+	health = 150
+	//melee if you get close, intended to be a ripper
+	harm_intent_damage = 5
+	melee_damage_lower = 25
+	melee_damage_upper = 25
+	attacktext = "Swing his ripper "
+	attack_sound = 'sound/weapons/drill.ogg'
+	//melee end
+	extra_projectiles = 1
+	retreat_distance = 2
+	minimum_distance = 2
+	name = "Enclave soldier"
+	desc = "A well armored veteran armed with a modified AER9."
+	icon_state = "syndicaterangedstormtrooper"
+	icon_living = "syndicaterangedstormtrooper"
+	projectilesound = 'sound/f13weapons/laser_rifle.ogg'
+	projectiletype = /obj/item/projectile/beam/laser/enclaveAER9
+	loot = list(/obj/effect/mob_spawn/human/corpse/enclavetrooper , /obj/effect/spawner/lootdrop/f13/Enclavesoldier)
+
+	speak = list("REMEMBER THE RIG!","Engaging subhumans!!","Contact spotted!","BURN IN HELL!")
+	speak_emote = list("swear loudly")
+	emote_taunt = list("stares ferociously", "Aim his gun")
+	speak_chance = 10
+	taunt_chance = 25
+
+/mob/living/simple_animal/hostile/enclave/Elite //PA dude with a gatling, intended as a mini boss
+    //full burst kill anyone, altough a full burst takes two second to fire
+	ranged = 1
+	maxHealth = 750 //mother deathclaw HP pool, meant to represent his PA ( get me a spriter, REEEE!)
+	health = 750
+	harm_intent_damage = 5
+	melee_damage_lower = 75 // i mean it's a PA powerfisting, you won't enjoy it
+	melee_damage_upper = 75
+	attacktext = "Powerfists"
+	attack_sound = 'sound/weapons/punch1.ogg'
+	extra_projectiles = 9
+	retreat_distance = 0 //this guy ain't afraid of you
+	minimum_distance = 2 //try to stay close
+	name = "Enclave Elite"
+	desc = "A scary foe wearing advanced power armor and using a gatling laser, RUN!."
+	icon_state = "syndicaterangedspace"
+	icon_living = "syndicaterangedspace"
+	projectilesound = 'sound/f13weapons/laser_rifle.ogg'
+	projectiletype = /obj/item/projectile/beam/laser/enclaveAER7
+	speak = list("FOR NAVARRO","I'm here to kick your ass and chew bubblegum, AND I'M OUT OF BUBBLEGUM!","ENCLAVE, HURRAH!","DIE IN LASER FIRE!")
+	speak_emote = list("yell hatefully")
+	emote_taunt = list("stares ferociously trough the eyeslits", "spin his gun barrels")
+	speak_chance = 30
+	taunt_chance = 50
+	loot = list(/obj/effect/mob_spawn/human/corpse/enclaveelite , /obj/effect/spawner/lootdrop/f13/Enclaveelite)
+
+/mob/living/simple_animal/hostile/enclave/officer //just a flavor officer,cowardly but well armed,working on making him summon troops to his aid
+    //Plasma rifle, 2 shots for unarmored, 3 for T45 and CA, 4for T51
+	ranged = 1
+	maxHealth = 150 //Not that tanky but he will flee, making him a pain to deal with
+	health = 150
+	harm_intent_damage = 5
+	melee_damage_lower = 45 // powerfist but no PA augmented
+	melee_damage_upper = 45
+	attacktext = "Powerfists" //why the fuck are you in melee?
+	attack_sound = 'sound/weapons/punch1.ogg'
+	extra_projectiles = 0
+	retreat_distance = 7 //this guy is afraid of you
+	minimum_distance = 5 //try to stay behind his goons
+	name = "Enclave officer"
+	desc = "A ranking officer with a bruning hate for wasters. Prick."
+	icon_state = "russianrangedelite"
+	icon_living = "russianrangedelite"
+	projectilesound = 'sound/f13weapons/plasmarifle.ogg'
+	projectiletype = /obj/item/projectile/plasma
+	speak = list("Contacts! enact balleplan Sigma!","Troopers! Clean these abominations!","I WILL BURN YOUR BODIES!","Troopers! Get ready for a mutie hunt!")
+	speak_emote = list("talk in his headset")
+	emote_taunt = list("stares with disgust")
+	speak_chance = 30
+	taunt_chance = 50
+	loot = list(/obj/effect/mob_spawn/human/corpse/enclaveofficer , /obj/effect/spawner/lootdrop/f13/Enclaveofficer )
+/mob/living/simple_animal/hostile/enclave/officer/Aggro() //this line can be recycled for other mobs, all mobs belongign to the parent type "enclave" who can see him will come to his aid when he spots a PC....so he can run away
+	..()
+	summon_backup(15) //15 is the radius in which the goons react
+	say("MUTIE HUNTING TIME!" , "CONTACT! TO ME LADS!" , "COVER ME, FREAKING MUTIES ARE HERE!")

--- a/code/modules/mob/living/simple_animal/centaur.dm
+++ b/code/modules/mob/living/simple_animal/centaur.dm
@@ -1,0 +1,41 @@
+/mob/living/simple_animal/hostile/centaur
+	name = "Centaur"
+	desc = "The result of infection by FEV gone horribly wrong."
+	icon = 'icons/mob/wastemobs.dmi'
+	icon_state = "centaur"
+	icon_living = "centaur"
+	icon_dead = "centaur_d"
+	mob_biotypes = list(MOB_ORGANIC, MOB_HUMANOID)
+	stat_attack = UNCONSCIOUS
+	robust_searching = 1
+	turns_per_move = 5
+	speak_emote = list("growls")
+	emote_see = list("screeches")
+	a_intent = INTENT_HARM
+	maxHealth = 100
+	health = 100
+	speed = 2
+	harm_intent_damage = 15
+	melee_damage_lower = 15
+	melee_damage_upper = 15
+	ranged = 1
+	retreat_distance = 5
+	minimum_distance = 5
+	attacktext = "whipped"
+	attack_sound = 'sound/hallucinations/growl1.ogg'
+	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
+	unsuitable_atmos_damage = 20
+	robust_searching = 0
+	stat_attack = UNCONSCIOUS
+	gold_core_spawnable = HOSTILE_SPAWN
+	faction = list("supermutant")
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/human/centaur = 3,
+							/obj/item/stack/sheet/animalhide/human = 2,
+							/obj/item/stack/sheet/bone = 2)
+	projectiletype = /obj/item/projectile/neurotox
+	projectilesound = 'sound/weapons/pierce.ogg'
+
+/obj/item/projectile/neurotox
+	name = "spit"
+	damage = 30
+	icon_state = "toxin"

--- a/code/modules/mob/living/simple_animal/deathclaw.dm
+++ b/code/modules/mob/living/simple_animal/deathclaw.dm
@@ -1,0 +1,133 @@
+/mob/living/simple_animal/hostile/deathclaw
+	name = "deathclaw"
+	desc = "A massive, reptilian creature with powerful muscles, razor-sharp claws, and aggression to match."
+	icon = 'icons/mob/deathclaw.dmi'
+	icon_state = "deathclaw"
+	icon_living = "deathclaw"
+	icon_dead = "deathclaw_dead"
+	icon_gib = "deathclaw_gib"
+	gender = MALE
+	mob_biotypes = list(MOB_ORGANIC, MOB_BEAST)
+	stat_attack = UNCONSCIOUS
+	robust_searching = 1
+	anchored = 1
+	speak = list("ROAR!","Rawr!","GRRAAGH!","Growl!")
+	speak_emote = list("growls", "roars")
+	emote_hear = list("grumbles.","grawls.")
+	emote_taunt = list("stares ferociously", "stomps")
+	speak_chance = 10
+	taunt_chance = 25
+	speed = -1
+	see_in_dark = 8
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/deathclaw = 4,
+							/obj/item/stack/sheet/animalhide/deathclaw = 2,
+							/obj/item/stack/sheet/bone = 4)
+	loot = list(/obj/effect/spawner/lootdrop/f13/deathclaw)
+	response_help  = "pets"
+	response_disarm = "gently pushes aside"
+	response_harm   = "hits"
+	maxHealth = 500
+	health = 500
+	obj_damage = 60
+	armour_penetration = 30
+	melee_damage_lower = 56
+	melee_damage_upper = 56
+	attacktext = "claws"
+	attack_sound = 'sound/weapons/bladeslice.ogg'
+	friendly = "hugs"
+	faction = list("deathclaw")
+	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
+	unsuitable_atmos_damage = 5
+	gold_core_spawnable = HOSTILE_SPAWN
+	var/charging = FALSE
+
+/mob/living/simple_animal/hostile/deathclaw/mother
+	name = "mother deathclaw"
+	desc = "A massive, reptilian creature with powerful muscles, razor-sharp claws, and aggression to match. This one is an angry mother."
+	gender = FEMALE
+	maxHealth = 750
+	health = 750
+	melee_damage_lower = 72
+	melee_damage_upper = 72
+	armour_penetration = 30
+	color = rgb(95,104,94)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/deathclaw = 6,
+							/obj/item/stack/sheet/animalhide/deathclaw = 3)
+	loot = list(/obj/effect/spawner/lootdrop/f13/deathclawmother)
+
+/mob/living/simple_animal/hostile/deathclaw/bullet_act(obj/item/projectile/Proj)
+	if(!Proj)
+		return
+	if(prob(10))
+		visible_message("<span class='danger'>\The [src] growls, enraged!</span>")
+		sleep(3)
+		Charge()
+	if(prob(85) || Proj.damage > 26) //prob(x) = chance for proj to actually do something, adjust depending on how OP you want deathclaws to be
+		return ..()
+	else
+		visible_message("<span class='danger'>\The [Proj] bounces off \the [src]'s thick hide!</span>")
+		return 0
+
+/mob/living/simple_animal/hostile/deathclaw/do_attack_animation(atom/A, visual_effect_icon)
+	if(!charging)
+		..()
+
+/mob/living/simple_animal/hostile/deathclaw/AttackingTarget()
+	if(!charging)
+		return ..()
+
+/mob/living/simple_animal/hostile/deathclaw/Goto(target, delay, minimum_distance)
+	if(!charging)
+		..()
+
+/mob/living/simple_animal/hostile/deathclaw/Move()
+	if(charging)
+		new /obj/effect/temp_visual/decoy/fading(loc,src)
+		DestroySurroundings()
+	. = ..()
+	if(charging)
+		DestroySurroundings()
+
+/mob/living/simple_animal/hostile/deathclaw/proc/Charge()
+	var/turf/T = get_turf(target)
+	if(!T || T == loc)
+		return
+	charging = TRUE
+	visible_message("<span class='danger'>[src] charges!</span>")
+	DestroySurroundings()
+	walk(src, 0)
+	setDir(get_dir(src, T))
+	var/obj/effect/temp_visual/decoy/D = new /obj/effect/temp_visual/decoy(loc,src)
+	animate(D, alpha = 0, color = "#FF0000", transform = matrix()*2, time = 1)
+	sleep(3)
+	throw_at(T, get_dist(src, T), 1, src, 0, callback = CALLBACK(src, .proc/charge_end))
+
+/mob/living/simple_animal/hostile/deathclaw/proc/charge_end(list/effects_to_destroy)
+	charging = FALSE
+	if(target)
+		Goto(target, move_to_delay, minimum_distance)
+
+/mob/living/simple_animal/hostile/deathclaw/Bump(atom/A)
+	if(charging)
+		if(isturf(A) || isobj(A) && A.density)
+			A.ex_act(EXPLODE_HEAVY)
+		DestroySurroundings()
+	..()
+
+/mob/living/simple_animal/hostile/deathclaw/throw_impact(atom/A)
+	if(!charging)
+		return ..()
+
+	else if(isliving(A))
+		var/mob/living/L = A
+		L.visible_message("<span class='danger'>[src] slams into [L]!</span>", "<span class='userdanger'>[src] slams into you!</span>")
+		L.apply_damage(melee_damage_lower/2, BRUTE)
+		playsound(get_turf(L), 'sound/effects/meteorimpact.ogg', 100, 1)
+		shake_camera(L, 4, 3)
+		shake_camera(src, 2, 3)
+		var/throwtarget = get_edge_target_turf(src, get_dir(src, get_step_away(L, src)))
+		L.throw_at(throwtarget, 3)
+
+
+	charging = FALSE
+	charging = FALSE

--- a/code/modules/mob/living/simple_animal/ghoul.dm
+++ b/code/modules/mob/living/simple_animal/ghoul.dm
@@ -1,0 +1,77 @@
+/mob/living/simple_animal/hostile/ghoul
+	name = "feral ghoul"
+	desc = "A ghoul that has lost it's mind and become aggressive."
+	icon = 'icons/mob/wastemobs.dmi'
+	icon_state = "feralghoul"
+	icon_living = "feralghoul"
+	icon_dead = "feralghoul_dead"
+	mob_biotypes = list(MOB_ORGANIC, MOB_HUMANOID)
+	stat_attack = UNCONSCIOUS
+	robust_searching = 1
+	turns_per_move = 5
+	speak_emote = list("growls")
+	emote_see = list("screeches")
+	a_intent = INTENT_HARM
+	maxHealth = 40
+	health = 40
+	speed = 2
+	harm_intent_damage = 15
+	melee_damage_lower = 15
+	melee_damage_upper = 15
+	attacktext = "claws"
+	attack_sound = 'sound/hallucinations/growl1.ogg'
+	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
+	unsuitable_atmos_damage = 20
+	robust_searching = 0
+	stat_attack = UNCONSCIOUS
+	gold_core_spawnable = HOSTILE_SPAWN
+	faction = list("ghoul")
+	decompose = TRUE
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/human/ghoul = 2,
+							/obj/item/stack/sheet/animalhide/human = 1,
+							/obj/item/stack/sheet/bone = 1)
+	loot = list(/obj/effect/spawner/lootdrop/f13/ghoul)
+
+/mob/living/simple_animal/hostile/ghoul/reaver
+	name = "feral ghoul reaver"
+	desc = "A ghoul that has lost it's mind and become aggressive. This one is strapped with metal armor, and appears far stronger."
+	icon = 'icons/mob/wastemobs.dmi'
+	icon_state = "ghoulreaver"
+	icon_living = "ghoulreaver"
+	icon_dead = "ghoulreaver_dead"
+	speed = 2
+	a_intent = INTENT_HARM
+	maxHealth = 100
+	health = 100
+	harm_intent_damage = 5
+	melee_damage_lower = 15
+	melee_damage_upper = 15
+	loot =list(/obj/effect/spawner/lootdrop/f13/ghoulreaver)
+
+/mob/living/simple_animal/hostile/ghoul/glowing
+	name = "glowing feral ghoul"
+	desc = "A feral ghoul that has absorbed massive amounts of radiation, causing them to glow in the dark and radiate constantly.."
+	icon_state = "glowinghoul"
+	icon_living = "glowinghoul"
+	icon_dead = "glowinghoul_dead"
+	maxHealth = 80
+	health = 80
+	speed = 2
+	harm_intent_damage = 10
+	melee_damage_lower = 20
+	melee_damage_upper = 20
+	loot =list(/obj/effect/spawner/lootdrop/f13/ghoulglowing)
+
+/mob/living/simple_animal/hostile/ghoul/glowing/Initialize()
+	. = ..()
+	set_light(2)
+
+/mob/living/simple_animal/hostile/ghoul/glowing/Aggro()
+	..()
+	summon_backup(10)
+
+/mob/living/simple_animal/hostile/ghoul/glowing/AttackingTarget()
+	. = ..()
+	if(. && ishuman(target))
+		var/mob/living/carbon/human/H = target
+		H.apply_effect(20, EFFECT_IRRADIATE, 0)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -92,7 +92,7 @@
 	var/my_z // I don't want to confuse this with client registered_z
 
 	//Stops the game from crashing
-	var/const/MAX_NPCs = 2500
+	var/const/MAX_NPCs = 999999
 	var/global/NPC_count = 0
 
 /mob/living/simple_animal/Initialize()

--- a/code/modules/mob/living/simple_animal/wastebots.dm
+++ b/code/modules/mob/living/simple_animal/wastebots.dm
@@ -1,0 +1,162 @@
+/mob/living/simple_animal/hostile/handy
+	name = "mr. handy"
+	desc = "A crazed pre-war household assistant robot, armed with a cutting saw."
+	icon = 'icons/mob/robots.dmi'
+	icon_state = "handy"
+	icon_living = "handy"
+	icon_dead = "gib7"
+	gender = NEUTER
+	mob_biotypes = list(MOB_ROBOTIC)
+	anchored = TRUE //unpullable
+	health = 160
+	maxHealth = 160
+	healable = 0
+	speed = 1
+	melee_damage_lower = 56
+	melee_damage_upper = 56
+	stat_attack = UNCONSCIOUS
+	robust_searching = 1
+	attacktext = "slaps"
+	attack_sound = 'sound/weapons/circsawhit.ogg'
+	faction = list("wastebot")
+	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
+	minbodytemp = 0
+	speak_emote = list("states")
+	gold_core_spawnable = HOSTILE_SPAWN
+	del_on_death = 1
+	loot = list(/obj/effect/decal/cleanable/robot_debris ,/obj/effect/spawner/lootdrop/f13/mrhandy )
+	deathmessage = "blows apart!"
+
+/mob/living/simple_animal/hostile/handy/Initialize()
+	. = ..()
+	add_overlay("eyes-[initial(icon_state)]")
+
+/mob/living/simple_animal/hostile/handy/gutsy
+	name = "mr. gutsy"
+	desc = "A pre-war combat robot based off the Mr. Handy design, armed with plasma weaponry and a deadly close-range flamer."
+	icon_state = "gutsy"
+	icon_living = "gutsy"
+	icon_dead = "gib7"
+	health = 200
+	maxHealth = 200
+	melee_damage_lower = 72
+	melee_damage_upper = 72
+	attack_sound = 'sound/items/welder.ogg'
+	attacktext = "shoots a burst of flame at"
+	projectilesound = 'sound/weapons/laser.ogg'
+	projectiletype = /obj/item/projectile/plasma/scatter
+	loot = list(/obj/effect/spawner/lootdrop/f13/mrgusty)
+	extra_projectiles = 2
+	ranged = TRUE
+	retreat_distance = 2
+	minimum_distance = 2
+	check_friendly_fire = TRUE
+
+/mob/living/simple_animal/hostile/handy/gutsy/AttackingTarget()
+	. = ..()
+
+/mob/living/simple_animal/hostile/handy/protectron
+	name = "protectron"
+	desc = "A pre-war security robot armed with deadly lasers."
+	icon_state = "protectron"
+	icon_living = "protectron"
+	icon_dead = "protectron_dead"
+	health = 160
+	maxHealth = 160
+	speed = 4
+	melee_damage_lower = 45
+	melee_damage_upper = 45
+	extra_projectiles = 2
+	ranged = TRUE
+	retreat_distance = 2
+	minimum_distance = 2
+	attacktext = "slaps"
+	attack_sound = 'sound/weapons/punch1.ogg'
+	projectilesound = 'sound/weapons/laser.ogg'
+	projectiletype = /obj/item/projectile/beam/laser/pistol
+	loot = list(/obj/effect/spawner/lootdrop/f13/protectrons)
+	faction = list("wastebot")
+	check_friendly_fire = TRUE
+
+/mob/living/simple_animal/pet/dog/protectron //Not an actual dog
+	name = "Trading Protectron"
+	desc = "A standard RobCo RX2 V1.16.4 \"Trade-o-Vend\", loaded with Trade protocols.<br>Looks like it was kept operational for an indefinite period of time. Its body is covered in cracks and dents of various sizes.<br>As it has been repaired countless times, it's amazing the machine is still functioning at all."
+	icon = 'icons/fallout/mobs/animal.dmi'
+	icon_state = "protectron"
+	icon_living = "protectron"
+	icon_dead = "protectron_d"
+	maxHealth = 200
+	health = 200
+	speak_chance = 5
+	faction = list("neutral", "silicon", "dog", "hostile", "pirate", "wastebot", "wolf", "plants", "turret", "enclave", "ghoul", "cazador", "supermutant", "gecko", "slime", "radscorpion", "skeleton", "carp", "bs", "bighorner")
+	speak = list("Welcome to my trading stale! On behalf of our company we wish you a to survive long enough to buy our products!", "Welcome back, traveler! How can I help you today? Fancy bying something from this vending machine? It is good!", "Line up for another great series of purchases! It will keep you alive a bit longer! Just a bit.", "My sensor tell it's almost 40 degrees Celsius in here. Good think I am trustworthy machine and not a sweating chunk of meat like you.", "You can blame the RobCo Industries for making androids with Genuine People Personalities. I'm a personality prototype. You can tell, can't you...?", "Remember three important rules of our trading stale! 1. No refunds. 2. No damaging the stale. 3. No refunds. Seriously.", "The first hundred years were the worst. And the second hundred - they were the worst, too. The third hundred I didn't enjoy at all. After that, I went into a bit of a decline.", "You think you've got problems. What are you supposed to do if you are a manically depressed robot? No, don't even bother answering. I'm 50,000 times more intelligent than you and even I don't know the answer.", "What a beautiful day! Shame I can't have a walk. On the other hand - I don't have to deal with all these terrible creatures out there. Speaking of which - you should totally buy something to protect yourself!")
+	speak_emote = list()
+	emote_hear = list()
+	emote_see = list()
+	response_help  = "shakes its manipulator"
+	response_disarm = "pushes"
+	response_harm   = "punches"
+	attack_sound = 'sound/voice/liveagain.ogg'
+	butcher_results = list(/obj/effect/gibspawner/robot = 1)
+
+/mob/living/simple_animal/hostile/handy/sentrybot
+	name = "sentry bot"
+	desc = "A pre-war military robot armed with a deadly gatling laser and covered in thick armor plating."
+	icon_state = "sentrybot"
+	icon_living = "sentrybot"
+	icon_dead = "sentrybot"
+	health = 280
+	maxHealth = 280
+	melee_damage_lower = 48
+	melee_damage_upper = 72
+	extra_projectiles = 5 //6 projectiles
+	ranged_cooldown_time = 12 //brrrrrrrrrrrrt
+	ranged = TRUE
+	retreat_distance = 2
+	minimum_distance = 2
+	del_on_death = FALSE
+	attacktext = "pulverizes"
+	attack_sound = 'sound/weapons/punch1.ogg'
+	projectilesound = 'sound/weapons/laser.ogg'
+	projectiletype = /obj/item/projectile/beam/laser/pistol/weak
+	loot =(/obj/effect/spawner/lootdrop/f13/sentrybot)
+	faction = list("wastebot")
+	check_friendly_fire = TRUE
+
+/obj/item/projectile/beam/laser/pistol/weak
+	damage = 15 //quantity over quality
+
+/mob/living/simple_animal/hostile/handy/sentrybot/bullet_act(obj/item/projectile/Proj)
+	if(!Proj)
+		CRASH("[src] sentrybot invoked bullet_act() without a projectile")
+	if(prob(10) && health > 1)
+		visible_message("<span class='danger'>\The [src] releases a defensive flashbang!</span>")
+		var/flashbang_turf = get_turf(src)
+		if(!flashbang_turf)
+			return
+		var/obj/item/grenade/flashbang/sentry/S = new /obj/item/grenade/flashbang/sentry(flashbang_turf)
+		S.preprime(user = null)
+	if(prob(75) || Proj.damage > 26) //prob(x) = chance for proj to actually do something, adjust depending on how OP you want sentrybots to be
+		return ..()
+	else
+		visible_message("<span class='danger'>\The [Proj] bounces off \the [src]'s armor plating!</span>")
+		return FALSE
+
+/mob/living/simple_animal/hostile/handy/sentrybot/proc/do_death_beep()
+	playsound(src, 'sound/machines/triple_beep.ogg', 75, TRUE)
+	visible_message("<span class='warning'>You hear an ominous beep coming from [src]!</span>", "<span class='warning'>You hear an ominous beep!</span>")
+
+/mob/living/simple_animal/hostile/handy/sentrybot/proc/self_destruct()
+	explosion(src,1,2,4,4)
+	qdel(src)
+
+/mob/living/simple_animal/hostile/handy/sentrybot/death()
+	do_sparks(3, TRUE, src)
+	for(var/i in 1 to 3)
+		addtimer(CALLBACK(src, .proc/do_death_beep), i * 1 SECONDS)
+	addtimer(CALLBACK(src, .proc/self_destruct), 4 SECONDS)
+	return ..()
+
+/mob/living/simple_animal/hostile/handy/sentrybot/Aggro()
+	. = ..()
+	summon_backup(15)


### PR DESCRIPTION
Changing the mob limit from 2500 to 999999, if it breaks we know where it is
Adding loottables to f13_lootdrop.dm
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

 Fixing mob limit and adding loot to mobs

## Description
 changed the max number of mobs
Added loot to most of the mobs, Covert will get the rest

## Motivation and Context
 limited to 2500 mobs before, now if it works we'll have 1million max mobs, dead and alive
Added loot to most of the mobs ( claws, ghouls,robots, muties, cnetaurs and enclaves) 
 

## How Has This Been Tested?
 compiled it fine, untested as it would be hard to reach the new limit
compiled fine, haven't tested the mobs
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
add: loot tables to f13lootdrop

tweak: tweaked the MAX_NPCs VAR and the .dms of the mobs

/:cl:
